### PR TITLE
feat: Google Search Console 所有権確認のために google-site-verification metadata を埋め込む

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,9 @@ const inter = Inter({ subsets: ["latin"] });
 export const metadata: Metadata = {
   title: "しゅん＠MxShun",
   description: "しゅん＠MxShunのプロフィール",
+  other: {
+    "google-site-verification": "yudmgra48wsLZh1gu_pz-IZrlk97CRHg3PattnExKl0", // NOTE: Google Search Console 所有権
+  }
 };
 
 export default function RootLayout({


### PR DESCRIPTION
[Google Analytics トラッキングコードによる所有者確認](https://support.google.com/webmasters/answer/9008080#meta_tag_verification&zippy=%2Cgoogle-%E3%82%A2%E3%83%8A%E3%83%AA%E3%83%86%E3%82%A3%E3%82%AF%E3%82%B9-%E3%83%88%E3%83%A9%E3%83%83%E3%82%AD%E3%83%B3%E3%82%B0-%E3%82%B3%E3%83%BC%E3%83%89) をするつもりだったが、`<head>` に gtag スクリプトを埋め込むのが上手くいかず。

refer
- https://support.google.com/webmasters/answer/9008080#meta_tag_verification&zippy=%2Chtml-%E3%82%BF%E3%82%B0